### PR TITLE
Update S3 credentials error message test

### DIFF
--- a/tests/graildient_descent/test_gd_utils.py
+++ b/tests/graildient_descent/test_gd_utils.py
@@ -67,9 +67,7 @@ class TestLoadData:
         Test that load_data raises EnvironmentError when S3 credentials are missing.
         """
         mock_getenv.return_value = None
-        with pytest.raises(
-            EnvironmentError, match="Yandex Cloud credentials not found"
-        ):
+        with pytest.raises(EnvironmentError, match="AWS credentials not found"):
             load_data("test.csv", from_s3=True, bucket_name="my-bucket")
 
     def test_load_data_s3_file_not_found(self, create_bucket):


### PR DESCRIPTION
- Change expected error message from Yandex Cloud to AWS
- Maintain consistent cloud provider references in tests