### PR TITLE
Set PYTHONPATH in GitHub Actions to ensure test discovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
         run: poetry install --with dev
 
       - name: Run Tests with pytest
-        run: poetry run pytest tests/ -v --cov=graildient_descent --cov-report=xml
+        run:
+          export PYTHONPATH=. && pytest tests/ -v --cov=graildient_descent
+          --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
- Export PYTHONPATH=. before running pytest