### PR TITLE
Fix pytest configuration in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
           echo "PYTHONPATH=." >> $GITHUB_ENV
 
       - name: Run Tests with pytest
-        run:
-          export PYTHONPATH=. && pytest tests/ -v --cov=graildient_descent
+        run: |
+          pytest tests/ -v --cov=graildient_descent
           --cov-report=xml
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
- Use GITHUB_ENV to set PYTHONPATH instead of export