### PR TITLE
chore: pin scikit-learn version and improve CI workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.11"
 pandas = "^2.2.2"
-scikit-learn = ">=1.3.0,<1.4.0"
+scikit-learn = ">=1.4.0,<1.5.0"
 gensim = "^4.3.3"
 nltk = "^3.8.2"
 category-encoders = "^2.6.3"


### PR DESCRIPTION
- Add explicit version constraint for scikit-learn (<1.53.0) to maintain compatibility with category-encoders